### PR TITLE
Fix cache invalidation uses pattern search

### DIFF
--- a/src/lib/strapi/strapi-client.ts
+++ b/src/lib/strapi/strapi-client.ts
@@ -173,7 +173,7 @@ class StrapiClient {
    * Invalidate cache by pattern
    */
   async invalidateCache(pattern: string): Promise<void> {
-    await cacheManager.delete(`strapi:${pattern}*`);
+    await cacheManager.invalidate([`strapi:${pattern}*`]);
   }
 
   /**


### PR DESCRIPTION
## Summary
- fix cache invalidation so wildcard patterns actually remove matching entries

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686bed07d5608325aaabc40f747c82d6