### PR TITLE
Optimize homepage hero image LCP

### DIFF
--- a/src/components/common/Image/Image.tsx
+++ b/src/components/common/Image/Image.tsx
@@ -66,6 +66,7 @@ export function Image({
   className,
   loading = "lazy",
   priority = false,
+  fetchPriority,
   quality = 85,
   sizes,
   placeholder = "blur",
@@ -414,6 +415,7 @@ export function Image({
         sizes={imageSizes}
         quality={quality}
         priority={priority}
+        fetchPriority={fetchPriority || (priority ? "high" : undefined)}
         placeholder={placeholder === "blur" && blurUrl ? "blur" : "empty"}
         blurDataURL={blurUrl}
         loading={priority ? "eager" : loading}
@@ -438,6 +440,7 @@ export function Image({
           sizes={imageSizes}
           quality={quality}
           priority
+          fetchPriority={fetchPriority}
           className="absolute inset-0 z-10"
           style={imageStyles}
           onLoad={() => setCurrentSrc(src)}

--- a/src/components/common/IntroWithImage/IntroWithImage.tsx
+++ b/src/components/common/IntroWithImage/IntroWithImage.tsx
@@ -202,6 +202,7 @@ export function IntroWithImage({
               width={525}
               height={200}
               priority={true}
+              fetchPriority="high"
               className="w-full h-full object-cover"
               sizes="(max-width: 1024px) 100vw, 50vw"
               quality={90}

--- a/src/types/image.types.ts
+++ b/src/types/image.types.ts
@@ -21,6 +21,11 @@ export interface ImageProps {
   // Next.js Image properties
   loading?: "lazy" | "eager";
   priority?: boolean;
+  /**
+   * Hint to the browser about the image's fetch priority.
+   * Maps to the HTML `fetchpriority` attribute.
+   */
+  fetchPriority?: "high" | "low" | "auto";
   quality?: number;
   sizes?: string;
   placeholder?: "blur" | "empty" | "none";


### PR DESCRIPTION
## Summary
- expose `fetchPriority` on ImageProps
- forward `fetchPriority` through Image component
- mark the homepage hero image with `fetchPriority="high"`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686c208bdb8083258cc2c0d44610c204