### PR TITLE
Optimize theme CSS and add preconnect hints

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -113,11 +113,27 @@ export default async function RootLayout({
           type="image/x-icon"
         />
 
-        {/* Preconnect to critical third-party origins */}
-        <link rel="preconnect" href={process.env.NEXT_PUBLIC_API_URL || ""} />
+        {/* Preconnect to critical origins */}
+        <link
+          rel="preconnect"
+          href={process.env.NEXT_PUBLIC_API_URL || ""}
+          crossOrigin="anonymous"
+        />
         <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_API_URL || ""} />
+        <link
+          rel="preconnect"
+          href={process.env.NEXT_PUBLIC_SITE_URL || ""}
+          crossOrigin="anonymous"
+        />
+        <link rel="dns-prefetch" href={process.env.NEXT_PUBLIC_SITE_URL || ""} />
 
         {/* Additional performance optimizations */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
         <link rel="dns-prefetch" href="//fonts.googleapis.com" />
         <link rel="dns-prefetch" href="//fonts.gstatic.com" />
 

--- a/src/app/themes/gds-theme.css
+++ b/src/app/themes/gds-theme.css
@@ -1,5 +1,4 @@
 /* src/styles/themes/gds-theme.css */
-@import "./base-theme.css";
 
 :root {
   /* Essential colors that Tailwind expects */


### PR DESCRIPTION
## Summary
- remove CSS `@import` to shorten the critical path
- preconnect to API, site and font origins

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686c20df4b2c832588a16ad6dd09446e