### PR TITLE
Preselect casino filter from dynamic block

### DIFF
--- a/src/components/widgets/CasinoList/CasinoFilters.tsx
+++ b/src/components/widgets/CasinoList/CasinoFilters.tsx
@@ -20,9 +20,7 @@ import {
   CONDITION_OPTIONS,
   BONUS_AMOUNT_OPTIONS,
   WAGERING_OPTIONS,
-  CASINO_FILTER_TO_SORT,
 } from "@/lib/utils/sort-mappings";
-import { normalizeCasinoFilter } from "@/lib/utils/casino";
 
 /**
  * CasinoFilters Component
@@ -43,20 +41,10 @@ export function CasinoFilters({
   translations = {},
   className,
   loading = false,
-  defaultFilter,
 }: CasinoFiltersProps) {
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const dropdownRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
 
-  // Apply default filter from block on mount
-  useEffect(() => {
-    if (!defaultFilter) return;
-    const bonusKey = normalizeCasinoFilter(defaultFilter);
-    if (bonusKey !== selectedFilters.bonusKey) {
-      onFilterChange({ bonusKey, sort: CASINO_FILTER_TO_SORT[bonusKey] });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Get label by value helper
   const getLabelByValue = (

--- a/src/components/widgets/CasinoList/CasinoFilters.tsx
+++ b/src/components/widgets/CasinoList/CasinoFilters.tsx
@@ -20,7 +20,9 @@ import {
   CONDITION_OPTIONS,
   BONUS_AMOUNT_OPTIONS,
   WAGERING_OPTIONS,
+  CASINO_FILTER_TO_SORT,
 } from "@/lib/utils/sort-mappings";
+import { normalizeCasinoFilter } from "@/lib/utils/casino";
 
 /**
  * CasinoFilters Component
@@ -41,9 +43,20 @@ export function CasinoFilters({
   translations = {},
   className,
   loading = false,
+  defaultFilter,
 }: CasinoFiltersProps) {
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const dropdownRefs = useRef<{ [key: string]: HTMLDivElement | null }>({});
+
+  // Apply default filter from block on mount
+  useEffect(() => {
+    if (!defaultFilter) return;
+    const bonusKey = normalizeCasinoFilter(defaultFilter);
+    if (bonusKey !== selectedFilters.bonusKey) {
+      onFilterChange({ bonusKey, sort: CASINO_FILTER_TO_SORT[bonusKey] });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Get label by value helper
   const getLabelByValue = (

--- a/src/components/widgets/CasinoList/CasinoListWidget.tsx
+++ b/src/components/widgets/CasinoList/CasinoListWidget.tsx
@@ -19,6 +19,7 @@ import { getCasinos, getCasinoProviders } from "@/app/actions/casinos";
 import { MobileCasinoFiltersSkeleton } from "./MobileCasinoFiltersSkeleton";
 import { MobileCasinoFilters } from "./MobileCasinoFilters";
 import { normalizeCasinoFilter } from "@/lib/utils/casino";
+import { normalizeCasinoSort } from "@/lib/utils";
 
 // Initial filter state
 const initialFilters: CasinoFiltersState = {
@@ -61,10 +62,12 @@ export function CasinoListWidget({
 
   // Determine initial bonus filter based on block settings
   const initialBonusKey = normalizeCasinoFilter(block.casinoFilters);
+  const initialSort = normalizeCasinoSort(block.casinoSort, initialFilters.sort);
 
   const blockInitialFilters: CasinoFiltersState = {
     ...initialFilters,
     bonusKey: initialBonusKey,
+    sort: initialSort,
   };
 
   // Calculate initial displayed casinos to prevent layout shift

--- a/src/components/widgets/CasinoList/CasinoListWidget.tsx
+++ b/src/components/widgets/CasinoList/CasinoListWidget.tsx
@@ -18,6 +18,8 @@ import { cn } from "@/lib/utils/cn";
 import { getCasinos, getCasinoProviders } from "@/app/actions/casinos";
 import { MobileCasinoFiltersSkeleton } from "./MobileCasinoFiltersSkeleton";
 import { MobileCasinoFilters } from "./MobileCasinoFilters";
+import { CASINO_FILTER_TO_SORT } from "@/lib/utils/sort-mappings";
+import { normalizeCasinoFilter } from "@/lib/utils/casino";
 
 // Initial filter state
 const initialFilters: CasinoFiltersState = {
@@ -58,6 +60,17 @@ export function CasinoListWidget({
   const itemsPerPage = block.numberPerLoadMore || 10;
   const usePagination = block.usePagination || false;
 
+  // Determine initial filters based on block settings
+  const initialBonusKey = normalizeCasinoFilter(block.casinoFilters);
+  const initialSort =
+    CASINO_FILTER_TO_SORT[initialBonusKey] || initialFilters.sort;
+
+  const blockInitialFilters: CasinoFiltersState = {
+    ...initialFilters,
+    bonusKey: initialBonusKey,
+    sort: initialSort,
+  };
+
   // Calculate initial displayed casinos to prevent layout shift
   const getInitialDisplayedCasinos = () => {
     if (!initialCasinos.length) return [];
@@ -81,7 +94,7 @@ export function CasinoListWidget({
     initialProviders || []
   );
   const [providersLoading, setProvidersLoading] = useState(false);
-  const [filters, setFilters] = useState<CasinoFiltersState>(initialFilters);
+  const [filters, setFilters] = useState<CasinoFiltersState>(blockInitialFilters);
   const [currentPage, setCurrentPage] = useState(initialPage);
   const [hasAppliedFilters, setHasAppliedFilters] = useState(false);
 
@@ -267,6 +280,7 @@ export function CasinoListWidget({
                     onClearFilters={handleClearFilters}
                     translations={translations}
                     loading={loading}
+                    defaultFilter={block.casinoFilters}
                   />
                 </div>
 
@@ -279,6 +293,7 @@ export function CasinoListWidget({
                     onClearFilters={handleClearFilters}
                     translations={translations}
                     loading={loading}
+                    defaultFilter={block.casinoFilters}
                   />
                 </div>
               </>

--- a/src/components/widgets/CasinoList/CasinoListWidget.tsx
+++ b/src/components/widgets/CasinoList/CasinoListWidget.tsx
@@ -18,7 +18,6 @@ import { cn } from "@/lib/utils/cn";
 import { getCasinos, getCasinoProviders } from "@/app/actions/casinos";
 import { MobileCasinoFiltersSkeleton } from "./MobileCasinoFiltersSkeleton";
 import { MobileCasinoFilters } from "./MobileCasinoFilters";
-import { CASINO_FILTER_TO_SORT } from "@/lib/utils/sort-mappings";
 import { normalizeCasinoFilter } from "@/lib/utils/casino";
 
 // Initial filter state
@@ -60,17 +59,12 @@ export function CasinoListWidget({
   const itemsPerPage = block.numberPerLoadMore || 10;
   const usePagination = block.usePagination || false;
 
-  // Determine initial filters based on block settings
+  // Determine initial bonus filter based on block settings
   const initialBonusKey = normalizeCasinoFilter(block.casinoFilters);
-  const initialSort =
-    block.casinoSort ||
-    CASINO_FILTER_TO_SORT[initialBonusKey] ||
-    initialFilters.sort;
 
   const blockInitialFilters: CasinoFiltersState = {
     ...initialFilters,
     bonusKey: initialBonusKey,
-    sort: initialSort,
   };
 
   // Calculate initial displayed casinos to prevent layout shift

--- a/src/components/widgets/CasinoList/CasinoListWidget.tsx
+++ b/src/components/widgets/CasinoList/CasinoListWidget.tsx
@@ -63,7 +63,9 @@ export function CasinoListWidget({
   // Determine initial filters based on block settings
   const initialBonusKey = normalizeCasinoFilter(block.casinoFilters);
   const initialSort =
-    CASINO_FILTER_TO_SORT[initialBonusKey] || initialFilters.sort;
+    block.casinoSort ||
+    CASINO_FILTER_TO_SORT[initialBonusKey] ||
+    initialFilters.sort;
 
   const blockInitialFilters: CasinoFiltersState = {
     ...initialFilters,

--- a/src/components/widgets/CasinoList/CasinoListWidget.tsx
+++ b/src/components/widgets/CasinoList/CasinoListWidget.tsx
@@ -280,7 +280,6 @@ export function CasinoListWidget({
                     onClearFilters={handleClearFilters}
                     translations={translations}
                     loading={loading}
-                    defaultFilter={block.casinoFilters}
                   />
                 </div>
 
@@ -293,7 +292,6 @@ export function CasinoListWidget({
                     onClearFilters={handleClearFilters}
                     translations={translations}
                     loading={loading}
-                    defaultFilter={block.casinoFilters}
                   />
                 </div>
               </>

--- a/src/components/widgets/CasinoList/MobileCasinoFilters.tsx
+++ b/src/components/widgets/CasinoList/MobileCasinoFilters.tsx
@@ -25,9 +25,7 @@ import {
   CONDITION_OPTIONS,
   BONUS_AMOUNT_OPTIONS,
   WAGERING_OPTIONS,
-  CASINO_FILTER_TO_SORT,
 } from "@/lib/utils/sort-mappings";
-import { normalizeCasinoFilter } from "@/lib/utils/casino";
 import { cn } from "@/lib/utils/cn";
 // ADD PORTAL IMPORTS
 import { DropdownPortal } from "@/components/common/Portal/DropdownPortal";
@@ -40,7 +38,6 @@ export function MobileCasinoFilters({
   translations = {},
   className = "",
   loading = false,
-  defaultFilter,
 }: CasinoFiltersProps) {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isSortOpen, setIsSortOpen] = useState(false);
@@ -54,15 +51,6 @@ export function MobileCasinoFilters({
     label: translations?.[option.label] || option.label,
   }));
 
-  // Apply default filter on mount
-  useEffect(() => {
-    if (!defaultFilter) return;
-    const bonusKey = normalizeCasinoFilter(defaultFilter);
-    if (bonusKey !== selectedFilters.bonusKey) {
-      onFilterChange({ bonusKey, sort: CASINO_FILTER_TO_SORT[bonusKey] });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Calculate if there are active filters
   const hasActiveFilters =

--- a/src/components/widgets/CasinoList/MobileCasinoFilters.tsx
+++ b/src/components/widgets/CasinoList/MobileCasinoFilters.tsx
@@ -25,7 +25,9 @@ import {
   CONDITION_OPTIONS,
   BONUS_AMOUNT_OPTIONS,
   WAGERING_OPTIONS,
+  CASINO_FILTER_TO_SORT,
 } from "@/lib/utils/sort-mappings";
+import { normalizeCasinoFilter } from "@/lib/utils/casino";
 import { cn } from "@/lib/utils/cn";
 // ADD PORTAL IMPORTS
 import { DropdownPortal } from "@/components/common/Portal/DropdownPortal";
@@ -38,6 +40,7 @@ export function MobileCasinoFilters({
   translations = {},
   className = "",
   loading = false,
+  defaultFilter,
 }: CasinoFiltersProps) {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isSortOpen, setIsSortOpen] = useState(false);
@@ -50,6 +53,16 @@ export function MobileCasinoFilters({
     value: option.value,
     label: translations?.[option.label] || option.label,
   }));
+
+  // Apply default filter on mount
+  useEffect(() => {
+    if (!defaultFilter) return;
+    const bonusKey = normalizeCasinoFilter(defaultFilter);
+    if (bonusKey !== selectedFilters.bonusKey) {
+      onFilterChange({ bonusKey, sort: CASINO_FILTER_TO_SORT[bonusKey] });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Calculate if there are active filters
   const hasActiveFilters =

--- a/src/lib/utils/casino.ts
+++ b/src/lib/utils/casino.ts
@@ -120,3 +120,39 @@ export function getCasinoBadge(
 
   return null;
 }
+
+/** Mapping of CMS casino filter slugs to internal bonusKey values */
+const CASINO_FILTER_ALIASES: Record<string, string> = {
+  "bonus di benvenuto": "bonusSection",
+  "welcome bonus": "bonusSection",
+  welcome: "bonusSection",
+  "senza deposito": "noDepositSection",
+  "no deposit": "noDepositSection",
+  "giri gratis": "freeSpinsSection",
+  "free spins": "freeSpinsSection",
+};
+
+/**
+ * Normalize casino filter slug from CMS to a bonusKey value
+ */
+export function normalizeCasinoFilter(
+  filter: string | undefined,
+  defaultFilter: string = "bonusSection"
+): string {
+  if (!filter) return defaultFilter;
+
+  const normalized = filter.trim().toLowerCase();
+
+  if (CASINO_FILTER_ALIASES[normalized]) {
+    return CASINO_FILTER_ALIASES[normalized];
+  }
+
+  // Partial match support
+  for (const [alias, value] of Object.entries(CASINO_FILTER_ALIASES)) {
+    if (normalized.includes(alias.toLowerCase())) {
+      return value;
+    }
+  }
+
+  return defaultFilter;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -83,6 +83,7 @@ export {
   getStrapiSort,
   getMultipleSorts,
   normalizeGameSort,
+  normalizeCasinoSort,
 } from "./sort-mappings";
 
 // Re-export types

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -68,6 +68,7 @@ export {
   formatNoDepositBonus,
   isNewCasino,
   getCasinoBadge,
+  normalizeCasinoFilter,
 } from "./casino";
 
 // Sort mapping utilities

--- a/src/lib/utils/sort-mappings.ts
+++ b/src/lib/utils/sort-mappings.ts
@@ -201,6 +201,52 @@ export const CASINO_SORT_OPTIONS = [
   { value: "createdAt:desc", label: "casinoPostDate" },
 ] as const;
 
+/** Mapping of CMS casino sort names to internal values */
+const CASINO_SORT_ALIASES: Record<string, string> = {
+  "top rated": "ratingAvg:desc",
+  "top rated users": "ratingAvg:desc",
+  "più votati utenti": "ratingAvg:desc",
+  "piu votati utenti": "ratingAvg:desc",
+  "author rating": "authorRatings:desc",
+  "top rated author": "authorRatings:desc",
+  "bonus benvenuto": "bonusSection.bonusAmount:desc",
+  "welcome bonus": "bonusSection.bonusAmount:desc",
+  alphabetic: "title:asc",
+  "a-z": "title:asc",
+  alfabetico: "title:asc",
+  newest: "createdAt:desc",
+  "data di pubblicazione": "createdAt:desc",
+};
+
+/**
+ * Normalize casino sort value from CMS to internal format
+ */
+export function normalizeCasinoSort(
+  sortValue: string | undefined,
+  defaultSort: string = "ratingAvg:desc"
+): string {
+  if (!sortValue) return defaultSort;
+
+  const normalized = sortValue.trim().toLowerCase();
+
+  // Direct match with our option values
+  if (CASINO_SORT_OPTIONS.some((opt) => opt.value === sortValue)) {
+    return sortValue;
+  }
+
+  if (CASINO_SORT_ALIASES[normalized]) {
+    return CASINO_SORT_ALIASES[normalized];
+  }
+
+  for (const [alias, value] of Object.entries(CASINO_SORT_ALIASES)) {
+    if (normalized.includes(alias)) {
+      return value;
+    }
+  }
+
+  return defaultSort;
+}
+
 /**
  * Bonus type options
  */

--- a/src/lib/utils/sort-mappings.ts
+++ b/src/lib/utils/sort-mappings.ts
@@ -239,10 +239,5 @@ export const WAGERING_OPTIONS = [
   "60x",
 ];
 
-/** Mapping of bonus type keys to their default sort value */
-export const CASINO_FILTER_TO_SORT: Record<string, string> = {
-  bonusSection: "bonusSection.bonusAmount:desc",
-  noDepositSection: "noDepositSection.bonusAmount:desc",
-  freeSpinsSection: "freeSpinsSection.bonusAmount:desc",
-};
+
 

--- a/src/lib/utils/sort-mappings.ts
+++ b/src/lib/utils/sort-mappings.ts
@@ -238,3 +238,11 @@ export const WAGERING_OPTIONS = [
   "50x",
   "60x",
 ];
+
+/** Mapping of bonus type keys to their default sort value */
+export const CASINO_FILTER_TO_SORT: Record<string, string> = {
+  bonusSection: "bonusSection.bonusAmount:desc",
+  noDepositSection: "noDepositSection.bonusAmount:desc",
+  freeSpinsSection: "freeSpinsSection.bonusAmount:desc",
+};
+

--- a/src/types/casino-filters.types.ts
+++ b/src/types/casino-filters.types.ts
@@ -47,8 +47,6 @@ export interface CasinoFiltersProps {
   translations?: Record<string, string>;
   className?: string;
   loading?: boolean;
-  /** Optional default filter slug from the page block */
-  defaultFilter?: string;
 }
 
 /**

--- a/src/types/casino-filters.types.ts
+++ b/src/types/casino-filters.types.ts
@@ -47,6 +47,8 @@ export interface CasinoFiltersProps {
   translations?: Record<string, string>;
   className?: string;
   loading?: boolean;
+  /** Optional default filter slug from the page block */
+  defaultFilter?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- map casinoFilters values to filter keys
- allow passing `defaultFilter` to filter widgets
- preselect filters using casino block data
- move `normalizeCasinoFilter` to casino utils

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_686c1ecab4b883259b08df3fbea9d9d4