### PR TITLE
Remove dark mode support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -839,15 +839,6 @@
     animation: shimmer 1.5s infinite;
   }
 
-  /* Dark mode image loading */
-  .dark .image-loading {
-    background: linear-gradient(
-      90deg,
-      var(--color-gray-700),
-      var(--color-gray-600),
-      var(--color-gray-700)
-    );
-  }
 }
 
 /* Utility classes for font weights */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -42,10 +42,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   maximumScale: 5,
-  themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
-    { media: "(prefers-color-scheme: dark)", color: "#000000" },
-  ],
+  themeColor: "#ffffff",
 };
 
 // Dynamic metadata generation with site-specific favicon

--- a/src/app/slot-machine/[slug]/page.tsx
+++ b/src/app/slot-machine/[slug]/page.tsx
@@ -253,7 +253,7 @@ export default async function CategoryPage({
                       {casinos.map((casino) => (
                         <div
                           key={casino.id}
-                          className="bg-white dark:bg-gray-800 rounded-lg shadow-sm p-6"
+                          className="bg-white rounded-lg shadow-sm p-6"
                         >
                           <div className="flex items-center justify-between">
                             <div className="flex items-center gap-4">

--- a/src/components/ui/Skeleton/Skeleton.tsx
+++ b/src/components/ui/Skeleton/Skeleton.tsx
@@ -16,10 +16,10 @@ interface SkeletonProps {
 export function Skeleton({ className, children }: SkeletonProps) {
   return (
     <div
-      className={cn(
-        "animate-pulse rounded-md bg-gray-200 dark:bg-gray-700",
-        className
-      )}
+        className={cn(
+          "animate-pulse rounded-md bg-gray-200",
+          className
+        )}
       aria-label="Loading..."
     >
       {children}

--- a/src/components/widgets/GameListWidget/GameFilters.tsx
+++ b/src/components/widgets/GameListWidget/GameFilters.tsx
@@ -325,7 +325,7 @@ export function GameFilters({
                       "w-full text-left px-4 py-2 hover:bg-gray-100 transition-colors",
                       "text-sm md:text-base",
                       selectedSort === option.value &&
-                        "bg-gray-100 dark:bg-gray-700 font-medium"
+                        "bg-gray-100 font-medium"
                     )}
                   >
                     {option.label}

--- a/src/components/widgets/GameListWidget/GameFiltersSkeleton.tsx
+++ b/src/components/widgets/GameListWidget/GameFiltersSkeleton.tsx
@@ -16,26 +16,26 @@ interface GameFiltersSkeletonProps {
 export function GameFiltersSkeleton({ className }: GameFiltersSkeletonProps) {
   return (
     <div
-      className={cn(
-        "bg-white dark:bg-gray-800 rounded-lg shadow-sm p-4",
-        className
-      )}
+        className={cn(
+          "bg-white rounded-lg shadow-sm p-4",
+          className
+        )}
     >
       <div className="flex flex-wrap items-center gap-4">
         {/* Filter Icon and Label Skeleton */}
         <div className="flex items-center gap-2">
-          <div className="h-5 w-5 bg-gray-300 dark:bg-gray-600 rounded animate-pulse" />
-          <div className="h-5 w-16 bg-gray-300 dark:bg-gray-600 rounded animate-pulse" />
+          <div className="h-5 w-5 bg-gray-300 rounded animate-pulse" />
+          <div className="h-5 w-16 bg-gray-300 rounded animate-pulse" />
         </div>
 
         {/* Sort Dropdown Skeleton */}
-        <div className="h-10 w-40 bg-gray-300 dark:bg-gray-600 rounded-lg animate-pulse" />
+        <div className="h-10 w-40 bg-gray-300 rounded-lg animate-pulse" />
 
         {/* Provider Filter Skeleton */}
-        <div className="h-10 w-32 bg-gray-300 dark:bg-gray-600 rounded-lg animate-pulse" />
+        <div className="h-10 w-32 bg-gray-300 rounded-lg animate-pulse" />
 
         {/* Category Filter Skeleton */}
-        <div className="h-10 w-32 bg-gray-300 dark:bg-gray-600 rounded-lg animate-pulse" />
+        <div className="h-10 w-32 bg-gray-300 rounded-lg animate-pulse" />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- strip `dark:` styles from widget skeletons, game filters, skeleton UI and slot machine page
- drop dark theme color meta tag
- remove the dark `.image-loading` rule

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_686ceecd85cc8325a9a893fa06cface7