### PR TITLE
Fix game rating fetch

### DIFF
--- a/src/components/games/GameCard/GameCard.tsx
+++ b/src/components/games/GameCard/GameCard.tsx
@@ -8,6 +8,7 @@ import { Image } from "@/components/common/Image";
 import { FavoriteButton } from "@/components/features/Favorites/FavoriteButton";
 import type { GameCardProps } from "@/types/game.types";
 import { cn } from "@/lib/utils/cn";
+import { useRatingData } from "@/lib/hooks/useRatingData";
 
 /**
  * GameCard Component
@@ -41,6 +42,14 @@ export function GameCard({
   const gameImage = Array.isArray(game.images) ? game.images[0] : game.images;
   const hasImage = gameImage && gameImage.url;
 
+  // Fetch latest rating data in case the provided values are stale
+  const { ratingAvg } = useRatingData(
+    game.documentId || game.id,
+    "games",
+    game.ratingAvg,
+    game.ratingCount || 0
+  );
+
   // Calculate if game is new (within 14 days)
   const isNewGame = () => {
     if (!game.createdAt) return false;
@@ -51,7 +60,7 @@ export function GameCard({
     return daysDiff <= 14;
   };
 
-  const isHotGame = game.ratingAvg > 4.5;
+  const isHotGame = ratingAvg > 4.5;
 
   // Badge configuration
   const badgeConfig = isHotGame
@@ -245,7 +254,7 @@ export function GameCard({
               <div
                 className="flex items-center gap-0.5"
                 role="img"
-                aria-label={`Rating: ${game.ratingAvg.toFixed(1)} out of 5`}
+                aria-label={`Rating: ${ratingAvg.toFixed(1)} out of 5`}
               >
                 <svg
                   className="w-2.5 h-2.5 text-warning flex-shrink-0"
@@ -256,7 +265,7 @@ export function GameCard({
                   <path d="M10 15l-5.878 3.09 1.123-6.545L.489 6.91l6.572-.955L10 0l2.939 5.955 6.572.955-4.756 4.635 1.123 6.545z" />
                 </svg>
                 <span className="text-[10px] text-grey-300">
-                  {game.ratingAvg.toFixed(1)}/5
+                  {ratingAvg.toFixed(1)}/5
                 </span>
               </div>
             </div>

--- a/src/components/games/GamePlayer/GamePlayer.tsx
+++ b/src/components/games/GamePlayer/GamePlayer.tsx
@@ -19,6 +19,7 @@ import { FullscreenPortal } from "@/components/common/Portal/FullscreenPortal"; 
 import type { GamePlayerProps } from "@/types/game-page.types";
 import { cn } from "@/lib/utils/cn";
 import { ReportGameModal } from "./ReportGame";
+import { useRatingData } from "@/lib/hooks/useRatingData";
 
 /**
  * Utility function to check if a string contains an iframe tag
@@ -157,14 +158,22 @@ export function GamePlayer({ game, translations = {} }: GamePlayerProps) {
   const gameImage = Array.isArray(game.images) ? game.images[0] : game.images;
   const hasImage = gameImage && gameImage.url;
 
+  // Fetch latest rating data for accurate display
+  const { ratingAvg, ratingCount } = useRatingData(
+    game.documentId || game.id,
+    "games",
+    game.ratingAvg,
+    game.ratingCount
+  );
+
   // Create a normalized game object with default values for optional date fields - KEEP ORIGINAL
   const normalizedGame = {
     id: game.id,
     documentId: game.documentId,
     title: game.title,
     slug: game.slug,
-    ratingAvg: game.ratingAvg,
-    ratingCount: game.ratingCount,
+    ratingAvg,
+    ratingCount,
     publishedAt: game.publishedAt,
     provider: game.provider,
     images: gameImage,
@@ -340,8 +349,8 @@ export function GamePlayer({ game, translations = {} }: GamePlayerProps) {
               <StarRatingInteractive
                 documentId={game.documentId}
                 slug={game.slug}
-                initialRating={game.ratingAvg}
-                initialCount={game.ratingCount}
+                initialRating={ratingAvg}
+                initialCount={ratingCount}
                 size="md"
                 ratingType="games"
                 itemTitle={game.title}

--- a/src/components/widgets/GameListWidget/GameFilters.tsx
+++ b/src/components/widgets/GameListWidget/GameFilters.tsx
@@ -12,7 +12,6 @@ import type { GameFiltersProps } from "@/types/game-list-widget.types";
 import { cn } from "@/lib/utils/cn";
 import { GAME_SORT_OPTIONS } from "@/lib/utils/sort-mappings";
 import debounce from "lodash.debounce";
-import { log } from "console";
 import { SearchResult } from "@/types/search.types";
 import { MeiliSearch } from "meilisearch";
 import Link from "next/link";
@@ -134,15 +133,12 @@ export function GameFilters({
     [onSearchChange]
   );
 
-  // Handle search input changes
+  // Update local search state and trigger debounced search
   const handleSearchChange = (value: string) => {
-    console.log("search value", value);
     setLocalSearchQuery(value);
-    if (onSearchChange) {
-      setIsSearching(true);
-      debouncedSearch(value);
-    }
+    debouncedSearch(value);
   };
+
 
   // Clear search
   const clearSearch = () => {
@@ -362,10 +358,11 @@ export function GameFilters({
               <input
                 type="text"
                 ref={gameInputRef}
-                // value={localSearchQuery}
-                value={query}
-                // onChange={(e) => handleSearchChange(e.target.value)}
-                onChange={(e) => setQuery(e.target.value)}
+                value={localSearchQuery}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  handleSearchChange(e.target.value);
+                }}
                 placeholder={translations.search || "Search games..."}
                 className={cn(
                   "w-full pl-10 pr-10 py-2 rounded-lg border",

--- a/src/lib/api/rating-fetcher.ts
+++ b/src/lib/api/rating-fetcher.ts
@@ -15,9 +15,10 @@ export async function fetchRatingData(
   type: "games" | "casinos" = "games"
 ): Promise<RatingData | null> {
   try {
-    const apiUrl = process.env.NEXT_PUBLIC_STRAPI_URL || process.env.STRAPI_URL;
+    // Reuse the same env vars as other rating utilities
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || process.env.API_URL;
     const apiToken =
-      process.env.NEXT_PUBLIC_STRAPI_API_TOKEN || process.env.STRAPI_API_TOKEN;
+      process.env.NEXT_PUBLIC_API_TOKEN || process.env.API_TOKEN;
 
     if (!apiUrl || !apiToken) {
       console.error("[fetchRatingData] Missing API configuration");

--- a/src/lib/hooks/useRatingData.ts
+++ b/src/lib/hooks/useRatingData.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { fetchRatingData } from "@/lib/api/rating-fetcher";
+
+export function useRatingData(
+  documentId?: string | number,
+  type: "games" | "casinos" = "games",
+  initialRating: number = 0,
+  initialCount: number = 0
+) {
+  const [ratingAvg, setRatingAvg] = useState(initialRating);
+  const [ratingCount, setRatingCount] = useState(initialCount);
+
+  useEffect(() => {
+    if (!documentId) return;
+
+    fetchRatingData(String(documentId), type).then((data) => {
+      if (data) {
+        setRatingAvg(data.ratingAvg);
+        setRatingCount(data.ratingCount);
+      }
+    });
+  }, [documentId, type]);
+
+  return { ratingAvg, ratingCount };
+}


### PR DESCRIPTION
## Summary
- add `useRatingData` hook to retrieve up-to-date ratings
- update `GameCard` and `GamePlayer` to use the hook
- fix environment vars used by rating fetcher
- clean up GameFilters search handler

## Testing
- `npm run lint`
- `npm run build` *(fails: fetch failed during redirects)*

------
https://chatgpt.com/codex/tasks/task_b_6870e2924d688325bffd75f1723038c5