### PR TITLE
Fix rating data handling

### DIFF
--- a/src/components/games/GameCard/GameCard.tsx
+++ b/src/components/games/GameCard/GameCard.tsx
@@ -1,7 +1,7 @@
 // src/components/games/GameCard/GameCard.tsx
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { analytics } from "@/lib/analytics/analytics";
 import { Image } from "@/components/common/Image";
@@ -40,6 +40,15 @@ export function GameCard({
   // Get the first image from the array
   const gameImage = Array.isArray(game.images) ? game.images[0] : game.images;
   const hasImage = gameImage && gameImage.url;
+
+  // Log rating data for debugging
+  useEffect(() => {
+    console.log("[GameCard] rating data", {
+      slug: game.slug,
+      ratingAvg: game.ratingAvg,
+      ratingCount: game.ratingCount,
+    });
+  }, [game.slug, game.ratingAvg, game.ratingCount]);
 
   // Calculate if game is new (within 14 days)
   const isNewGame = () => {

--- a/src/lib/strapi/game-page-data-loader.ts
+++ b/src/lib/strapi/game-page-data-loader.ts
@@ -177,9 +177,18 @@ const getGameDynamicDataCached = cache(
         return null;
       }
 
+      const rawRatingAvg = response.data[0].ratingAvg;
+      const rawRatingCount = response.data[0].ratingCount;
+
       const dynamicData: GamePageSplitData["dynamicData"] = {
-        ratingAvg: response.data[0].ratingAvg,
-        ratingCount: response.data[0].ratingCount,
+        ratingAvg:
+          typeof rawRatingAvg === "string"
+            ? parseFloat(rawRatingAvg)
+            : rawRatingAvg || 0,
+        ratingCount:
+          typeof rawRatingCount === "string"
+            ? parseInt(rawRatingCount, 10)
+            : rawRatingCount || 0,
         views: response.data[0].views,
         isGameDisabled: response.data[0].isGameDisabled,
         gameDisableText: response.data[0].gameDisableText,

--- a/src/lib/strapi/strapi-client.ts
+++ b/src/lib/strapi/strapi-client.ts
@@ -385,11 +385,24 @@ class StrapiClient {
       },
     };
 
-    return this.fetchWithCache<GamesListResponse>(
+    const response = await this.fetchWithCache<GamesListResponse>(
       "games",
       query,
       CACHE_TTL.games
     );
+
+    // Normalize rating fields to numbers
+    response.games = response.games.map((g) => ({
+      ...g,
+      ratingAvg:
+        typeof g.ratingAvg === "string" ? parseFloat(g.ratingAvg) : g.ratingAvg,
+      ratingCount:
+        typeof g.ratingCount === "string"
+          ? parseInt(g.ratingCount as unknown as string, 10)
+          : g.ratingCount ?? 0,
+    }));
+
+    return response;
   }
 
   /**
@@ -471,7 +484,18 @@ class StrapiClient {
       data: GameData[];
       meta: { pagination: { total: number } };
     }>("games", query, CACHE_TTL.gameDetail);
-    return response.data?.[0] || null;
+
+    const game = response.data?.[0];
+    if (game) {
+      game.ratingAvg =
+        typeof game.ratingAvg === "string" ? parseFloat(game.ratingAvg) : game.ratingAvg;
+      game.ratingCount =
+        typeof game.ratingCount === "string"
+          ? parseInt(game.ratingCount as unknown as string, 10)
+          : game.ratingCount ?? 0;
+    }
+
+    return game || null;
   }
 
   /**
@@ -515,11 +539,23 @@ class StrapiClient {
       },
     };
 
-    return this.fetchWithCache<GamesListResponse>(
+    const response = await this.fetchWithCache<GamesListResponse>(
       "games",
       query,
       CACHE_TTL.games
     );
+
+    response.games = response.games.map((g) => ({
+      ...g,
+      ratingAvg:
+        typeof g.ratingAvg === "string" ? parseFloat(g.ratingAvg) : g.ratingAvg,
+      ratingCount:
+        typeof g.ratingCount === "string"
+          ? parseInt(g.ratingCount as unknown as string, 10)
+          : g.ratingCount ?? 0,
+    }));
+
+    return response;
   }
 
   /**


### PR DESCRIPTION
## Summary
- normalise rating fields to numbers in Strapi client
- ensure game page loader handles string ratings
- log rating data in `GameCard` for debugging

## Testing
- `npm run lint` *(fails: 'log' is defined but never used in GameFilters.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_6870f377c0688325aa3bdf7f7982f3c5