### PR TITLE
Publish rating updates immediately

### DIFF
--- a/src/app/actions/ratings.ts
+++ b/src/app/actions/ratings.ts
@@ -117,6 +117,22 @@ export async function updateRating({
       };
     }
 
+    // Automatically publish the updated entry if draft & publish is enabled
+    const publishUrl = `${apiUrl}/api/${ratingType}/${documentId}/actions/publish`;
+    const publishRes = await fetch(publishUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    });
+
+    if (!publishRes.ok) {
+      const publishError = await publishRes.text();
+      console.error(`[updateRating] Publish failed: ${publishRes.status}`, publishError);
+    }
+
     const responseData = await res.json();
     const updatedItem = responseData.data || responseData;
 


### PR DESCRIPTION
## Summary
- publish Strapi entries after rating updates so values aren't stuck in a modified state

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870f7147fa8832591a301ca0abe1755