### PR TITLE
Publish rating updates immediately

### DIFF
--- a/src/app/actions/ratings.ts
+++ b/src/app/actions/ratings.ts
@@ -117,6 +117,30 @@ export async function updateRating({
       };
     }
 
+    // Publish the updated entry using the document service API
+    const publishUrl = `${apiUrl}/api/document-service/status`;
+
+    const uid = ratingType === "games" ? "api::game.game" : "api::casino.casino";
+    const publishBody = {
+      context: { uid, id: parseInt(documentId, 10) },
+      status: "PUBLISHED",
+    };
+
+    const publishRes = await fetch(publishUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify(publishBody),
+    });
+
+    if (!publishRes.ok) {
+      const publishError = await publishRes.text();
+      console.error(`[updateRating] Publish failed: ${publishRes.status}`, publishError);
+    }
+
     const responseData = await res.json();
     const updatedItem = responseData.data || responseData;
 


### PR DESCRIPTION
## Summary
- publish rating updates via Strapi's document service API

## Testing
- `npm run lint` *(fails: unused variables in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_b_6870f7147fa8832591a301ca0abe1755